### PR TITLE
Added support for hinted formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Play-Json extensions
 #### Serialization of polymorphic types with tags
 To overcome ambiguities when using `formatSealed` one option is to use type-tags.
 `formatTagged` adds type-tag field during serialization and relies on this field during deserialization.
-`formatSealedTagged` also inspects type-tag information to choose correct child Format.
 
     sealed trait ApiRequest
     case class Withdraw(amount: BigDecimal) extends ApiRequest
@@ -106,7 +105,8 @@ To overcome ambiguities when using `formatSealed` one option is to use type-tags
       // Wrap standard formats with tagged ones
       implicit private val depositFmt = Jsonx.formatTagged(Json.format[Deposit])
       implicit private val withdrawFmt = Jsonx.formatTagged(Json.format[Withdraw])
-      implicit val apiFmt = Jsonx.formatSealedTagged[ApiRequest]
+
+      implicit val apiFmt = Jsonx.formatSealed[ApiRequest]
     }
 
     val deposit = Deposit(10)

--- a/src/main/scala/play-json.scala
+++ b/src/main/scala/play-json.scala
@@ -466,8 +466,12 @@ This can be caused by https://issues.scala-lang.org/browse/SI-7046 which can onl
           }
 
           def writes(value: $T): JsValue = _delegateFormat.writes(value) match {
-            case obj: JsObject => obj ++ JsObject(Map(_tags.field -> JsString(_tags.tagFor(classOf[$T]))))
-            case nonObj => throw new Exception(s"Cannot put type-tag to $${nonObj.getClass.getSimpleName} produced by Format["+${Literal(Constant(T.toString))}+"]. Tagging supported only for Formats that write JsObjects")
+            case obj: JsObject if obj.keys.contains(_tags.field) =>
+              throw new Exception(s"Cannot put type-tag to [$${classOf[$T]}]: member with name $${_tags.field} already exists")
+            case obj: JsObject =>
+              obj ++ JsObject(Map(_tags.field -> JsString(_tags.tagFor(classOf[$T]))))
+            case nonObj =>
+              throw new Exception(s"Cannot put type-tag to $${nonObj.getClass.getSimpleName} produced by Format["+${Literal(Constant(T.toString))}+"]. Tagging supported only for Formats that write JsObjects")
           }
         }
       }

--- a/src/test/scala/TypeHintsTest.scala
+++ b/src/test/scala/TypeHintsTest.scala
@@ -1,0 +1,56 @@
+package org.cvogt.test.play.json
+
+import org.scalatest.FunSuite
+
+import play.api.libs.json.Json
+import org.cvogt.play.json.{Jsonx, Hints}
+
+sealed trait ApiRequest
+case class Withdraw(amount: BigDecimal) extends ApiRequest
+case class Deposit(amount: BigDecimal) extends ApiRequest
+case class Batch(requests: List[ApiRequest])
+
+
+class TypeHintsTest extends FunSuite {
+
+  object ApiFormats {
+    implicit val hints = Hints.CaseInsensitivePreservingShortHints("_type")
+    implicit val depositFmt = Jsonx.formatHinted(Json.format[Deposit])
+    implicit val withdrawFmt = Jsonx.formatHinted(Json.format[Withdraw])
+  }
+  test("json formatHinted") {
+    import ApiFormats._
+
+    val deposit = Deposit(99.9)
+    assert((Json.toJson(deposit) \ "_type").as[String] === "Deposit")
+    assert((Json.toJson(deposit) \ "amount").as[BigDecimal] === 99.9)
+    assert(Json.parse(s"""{"_type": "DePoSiT", "amount": 99.9}""").as[Deposit] === deposit)
+
+    val withdraw = Withdraw(10L)
+    assert((Json.toJson(withdraw) \ "_type").as[String] === "Withdraw")
+    assert((Json.toJson(withdraw) \ "amount").as[BigDecimal] === 10)
+    assert(Json.parse(s"""{"_type": "withdraw", "amount": 10.0}""").as[Withdraw] === withdraw)
+  }
+
+
+  object RootApiFormats {
+    import ApiFormats._
+    implicit val hints = Hints.CaseInsensitivePreservingShortHints("_type")
+    implicit val apifmt = Jsonx.formatHintedSealed[ApiRequest]
+    implicit val batchfmt = Json.format[Batch]
+  }
+
+  test("json formatHintedSealed") {
+    import RootApiFormats._
+    val deposit = Deposit(20)
+    val withdraw = Withdraw(10)
+    val batch = Batch(List(deposit, withdraw))
+
+    assert(((Json.toJson(batch) \ "requests")(0) \ "_type").as[String] === "Deposit")
+    assert(((Json.toJson(batch) \ "requests")(1) \ "_type").as[String] === "Withdraw")
+
+    assert(Json.parse(s"""{"_type": "withdraw", "amount": 10.0}""").as[ApiRequest] === withdraw)
+    assert(Json.parse(s"""{"_type": "deposit", "amount": 20.0}""").as[ApiRequest] === deposit)
+  }
+
+}

--- a/src/test/scala/TypeTagsTest.scala
+++ b/src/test/scala/TypeTagsTest.scala
@@ -44,16 +44,13 @@ class TypeTagsTest extends FunSuite {
 
 
   object RootApiFormats {
-    private implicit val tags = Tags.CaseInsensitivePreservingShortTags("_type")
+    import ApiFormats._
 
-    private implicit val depositFmt = Json.format[Deposit]
-    private implicit val withdrawFmt = Json.format[Withdraw]
-
-    implicit val apifmt = Jsonx.formatSealedTagged[ApiRequest]
+    implicit val apifmt = Jsonx.formatSealed[ApiRequest]
     implicit val batchfmt = Json.format[Batch]
   }
 
-  test("json formatSealedTagged") {
+  test("json formatSealed with formatTagged") {
     import RootApiFormats._
     val deposit = Deposit(20)
     val withdraw = Withdraw(10)

--- a/src/test/scala/TypeTagsTest.scala
+++ b/src/test/scala/TypeTagsTest.scala
@@ -3,7 +3,7 @@ package org.cvogt.test.play.json
 import org.scalatest.FunSuite
 
 import play.api.libs.json.Json
-import org.cvogt.play.json.{Jsonx, Hints}
+import org.cvogt.play.json.{Jsonx, Tags}
 
 sealed trait ApiRequest
 case class Withdraw(amount: BigDecimal) extends ApiRequest
@@ -11,14 +11,14 @@ case class Deposit(amount: BigDecimal) extends ApiRequest
 case class Batch(requests: List[ApiRequest])
 
 
-class TypeHintsTest extends FunSuite {
+class TypeTagsTest extends FunSuite {
 
   object ApiFormats {
-    implicit val hints = Hints.CaseInsensitivePreservingShortHints("_type")
-    implicit val depositFmt = Jsonx.formatHinted(Json.format[Deposit])
-    implicit val withdrawFmt = Jsonx.formatHinted(Json.format[Withdraw])
+    implicit val tags = Tags.CaseInsensitivePreservingShortTags("_type")
+    implicit val depositFmt = Jsonx.formatTagged(Json.format[Deposit])
+    implicit val withdrawFmt = Jsonx.formatTagged(Json.format[Withdraw])
   }
-  test("json formatHinted") {
+  test("json formatTagged") {
     import ApiFormats._
 
     val deposit = Deposit(99.9)
@@ -35,12 +35,12 @@ class TypeHintsTest extends FunSuite {
 
   object RootApiFormats {
     import ApiFormats._
-    implicit val hints = Hints.CaseInsensitivePreservingShortHints("_type")
-    implicit val apifmt = Jsonx.formatHintedSealed[ApiRequest]
+    implicit val tags = Tags.CaseInsensitivePreservingShortTags("_type")
+    implicit val apifmt = Jsonx.formatSealedTagged[ApiRequest]
     implicit val batchfmt = Json.format[Batch]
   }
 
-  test("json formatHintedSealed") {
+  test("json formatSealedTagged") {
     import RootApiFormats._
     val deposit = Deposit(20)
     val withdraw = Withdraw(10)


### PR DESCRIPTION
Hi Christopher! Please, review this proposal of possible solution for #18. I've borrowed some terminology from [json4s's](https://github.com/json4s/json4s#serializing-polymorphic-lists) polymorphic serialization and added some possibility to customize shape of type hints.
