### PR TITLE
Turn IllegalArgumentException into JsError in formatInline macro

### DIFF
--- a/src/main/scala/play-json.scala
+++ b/src/main/scala/play-json.scala
@@ -252,6 +252,22 @@ private[json] class Macros( val c: blackbox.Context ) {
     t
   }
 
+  private def illegalArgExceptionToJsError( inner: Tree ): Tree = {
+    q"""
+      {
+        import $pjson.{ JsSuccess, JsError, JsonValidationError }
+        try { JsSuccess($inner) }
+        catch {
+          case e: _root_.java.lang.IllegalArgumentException =>
+            val sw = new _root_.java.io.StringWriter()
+            val pw = new _root_.java.io.PrintWriter(sw)
+            e.printStackTrace(pw)
+            JsError(JsonValidationError(sw.toString,e))
+        }
+      }
+     """
+  }
+
   def formatInline[T: c.WeakTypeTag]: Tree = {
     val T = c.weakTypeOf[T]
     val fields = caseClassFieldsTypes( T )
@@ -262,7 +278,7 @@ private[json] class Macros( val c: blackbox.Context ) {
       {
         import $pjson.{ Json, Format, JsValue }
         new Format[$T]{
-          def reads(json: JsValue) = json.validate[$tpe].map(new $T(_))
+          def reads(json: JsValue) = json.validate[$tpe].flatMap(field => ${illegalArgExceptionToJsError( q"new $T(field)" )})
           def writes(obj: $T) = Json.toJson(obj.${TermName( field )})
         }
       }
@@ -297,7 +313,7 @@ private[json] class Macros( val c: blackbox.Context ) {
             val resolved = path.asSingleJsResult(json)
             val result = if(bpath.isInstanceOf[$pjson.JsDefined]) ${result} else ${orDefault( result, k )}
             (resolved,result) match {
-              case (_,result:JsSuccess[_]) => result
+              case (_,result:$pjson.JsSuccess[_]) => result
               case _ => resolved.flatMap(_ => result)
             }
           }
@@ -309,7 +325,7 @@ private[json] class Macros( val c: blackbox.Context ) {
 
     q"""
       {
-        import $pjson.{ OFormat, JsValue, JsResult, JsError, JsSuccess, JsObject, JsNull, JsonValidationError }
+        import $pjson.{ OFormat, JsValue, JsResult, JsError, JsObject, JsNull }
         new OFormat[$T]{
           def reads(json: JsValue) = {
             ..$mkResults
@@ -317,15 +333,7 @@ private[json] class Macros( val c: blackbox.Context ) {
               case JsError(values) => values
             }.flatten
             if(errors.isEmpty){
-              try{
-                JsSuccess(new $T(..${results.map( r => q"$r.get" )}))
-              } catch {
-                case e: _root_.java.lang.IllegalArgumentException =>
-                  val sw = new _root_.java.io.StringWriter()
-                  val pw = new _root_.java.io.PrintWriter(sw)
-                  e.printStackTrace(pw)
-                  JsError(JsonValidationError(sw.toString,e))
-              }
+              ${illegalArgExceptionToJsError( q"""new $T(..${results.map( r => q"$r.get" )})""" )}
             } else JsError(errors)
           }
           def writes(obj: $T) = JsObject(Seq[(String,JsValue)](..$jsonFields).filterNot(_._2 == JsNull))

--- a/src/test/scala/NoImport.scala
+++ b/src/test/scala/NoImport.scala
@@ -3,14 +3,14 @@ sealed trait Modifier
 case object early extends Modifier
 case object mid extends Modifier
 case object late extends Modifier
-case class Foo(i: Int)
-object a{
+case class Foo( i: Int )
+object a {
   import ai.x.play.json.SingletonEncoder.simpleName
   import ai.x.play.json.implicits.formatSingleton
   implicit def jsonFormat = ai.x.play.json.Jsonx.formatSealed[Modifier]
   implicit def jsonFormat2 = ai.x.play.json.Jsonx.formatCaseClass[Foo]
   implicit def jsonFormat3 = ai.x.play.json.Jsonx.formatInline[Foo]
 }
-object b{  
+object b {
   implicit def jsonFormat4 = ai.x.play.json.Jsonx.formatAuto[Foo]
 }


### PR DESCRIPTION
Follow-up on #49. Solves #48 

I had to create a new PR because the original repo is gone