### PR TITLE
Update README to communicate play-json 2.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Play-Json extensions
 
 **For Scala 2.11.x and 2.12.x**
 
+play-json 2.7.x: `libraryDependencies += "ai.x" %% "play-json-extensions" % "0.30.1"`
 play-json 2.6.x: `libraryDependencies += "ai.x" %% "play-json-extensions" % "0.30.1"`
 
 **For 2.11.x only**


### PR DESCRIPTION
Looking at the `build.sbt`, this library is compatible with Play-json `2.7.x`. Currently the `README` doesn't say this though. 